### PR TITLE
chore: unify cache and talk-page sync workflow

### DIFF
--- a/.github/workflows/cache-wikibase-and-build-profiles.yml
+++ b/.github/workflows/cache-wikibase-and-build-profiles.yml
@@ -1,4 +1,4 @@
-name: Cache Wikibase and Build Profiles
+name: Sync Wikibase Cache, Talk Pages, and Profiles
 
 on:
   workflow_dispatch:
@@ -13,13 +13,18 @@ on:
         required: false
         type: string
         default: ""
+      since:
+        description: Optional recentchanges replay start timestamp in ISO 8601 UTC
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
 
 jobs:
   refresh-cache-and-build-profiles:
-    name: Cache Wikibase and Build Profiles
+    name: Sync Wikibase Cache, Talk Pages, and Profiles
     runs-on: ubuntu-latest
 
     steps:
@@ -46,18 +51,39 @@ jobs:
       - name: Refresh entity cache from recentchanges
         env:
           INPUT_API_URL: ${{ inputs.api_url }}
+          INPUT_SINCE: ${{ inputs.since }}
         run: |
           mkdir -p "$SPIRITSAFE_ENTITIES_PATH" "$SPIRITSAFE_LOGS_PATH"
+          ARGS=(
+            --cache-dir "$SPIRITSAFE_ENTITIES_PATH"
+            --output "$SPIRITSAFE_LOGS_PATH/last_run_summary.json"
+          )
+
           if [ -n "$INPUT_API_URL" ]; then
-            gkc mash cache-wikibase-revisions \
-              --api-url "$INPUT_API_URL" \
-              --cache-dir "$SPIRITSAFE_ENTITIES_PATH" \
-              --output "$SPIRITSAFE_LOGS_PATH/last_run_summary.json"
-          else
-            gkc mash cache-wikibase-revisions \
-              --cache-dir "$SPIRITSAFE_ENTITIES_PATH" \
-              --output "$SPIRITSAFE_LOGS_PATH/last_run_summary.json"
+            ARGS+=(--api-url "$INPUT_API_URL")
           fi
+
+          if [ -n "$INPUT_SINCE" ]; then
+            ARGS+=(--since "$INPUT_SINCE")
+          fi
+
+          gkc mash cache-wikibase-revisions "${ARGS[@]}"
+
+      - name: Sync value-list artifacts from talk pages
+        env:
+          INPUT_API_URL: ${{ inputs.api_url }}
+        run: |
+          mkdir -p "$SPIRITSAFE_VALUE_LIST_QUERIES_PATH" "$SPIRITSAFE_VALUE_LIST_CACHE_PATH"
+          ARGS=(
+            --source local
+            --local-root .
+          )
+
+          if [ -n "$INPUT_API_URL" ]; then
+            ARGS+=(--api-url "$INPUT_API_URL")
+          fi
+
+          gkc --json profile value-lists sync "${ARGS[@]}"
 
       - name: Export JSON profiles from refreshed cache
         run: |
@@ -71,7 +97,7 @@ jobs:
         if: always()
         run: |
           if [ -f "$SPIRITSAFE_LOGS_PATH/last_run_summary.json" ]; then
-            python3 -c 'import json, os, pathlib; log_path = pathlib.Path(os.environ["SPIRITSAFE_LOGS_PATH"]) / "last_run_summary.json"; data = json.loads(log_path.read_text()); meta = data.get("metadata", {}); summ = data.get("summary", {}); lines = ["## Cache and Build Profiles Run Summary", "", "| Field | Value |", "| --- | --- |", "| API URL | `{}` |".format(meta.get("api_url", "")), "| Since | `{}` |".format(meta.get("since", "")), "| Next since | `{}` |".format(meta.get("next_since", "")), "| Changed | `{}` |".format(summ.get("changed_count", 0)), "| Refreshed | `{}` |".format(summ.get("refreshed_count", 0)), "| Deleted | `{}` |".format(summ.get("deleted_count", 0)), "| Ignored | `{}` |".format(summ.get("ignored_count", 0))]; summary_path = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]); existing = summary_path.read_text() if summary_path.exists() else ""; summary_path.write_text(existing + "\n".join(lines) + "\n")'
+            python3 -c 'import json, os, pathlib; log_path = pathlib.Path(os.environ["SPIRITSAFE_LOGS_PATH"]) / "last_run_summary.json"; data = json.loads(log_path.read_text()); meta = data.get("metadata", {}); summ = data.get("summary", {}); lines = ["## Cache, Talk Page, and Profile Sync Summary", "", "| Field | Value |", "| --- | --- |", "| API URL | `{}` |".format(meta.get("api_url", "")), "| Since | `{}` |".format(meta.get("since", "")), "| Next since | `{}` |".format(meta.get("next_since", "")), "| Changed | `{}` |".format(summ.get("changed_count", 0)), "| Refreshed | `{}` |".format(summ.get("refreshed_count", 0)), "| Deleted | `{}` |".format(summ.get("deleted_count", 0)), "| Ignored | `{}` |".format(summ.get("ignored_count", 0))]; summary_path = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]); existing = summary_path.read_text() if summary_path.exists() else ""; summary_path.write_text(existing + "\n".join(lines) + "\n")'
           fi
 
       - name: Remove legacy generated artifacts
@@ -84,8 +110,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A -- .
           if git diff --cached --quiet; then
-            echo "No cache or profile changes to commit"
+            echo "No cache, talk-page, or profile changes to commit"
           else
-            git commit -m "chore: refresh Wikibase cache and export profiles [skip ci]"
+            git commit -m "chore: sync Wikibase cache, talk pages, and profiles [skip ci]"
             git push origin "HEAD:${{ inputs.target_ref || github.ref_name }}"
           fi

--- a/config/dd-wikibase.yaml
+++ b/config/dd-wikibase.yaml
@@ -8,6 +8,15 @@ meta_wikibase:
     name_identifier_property_id: P214
     internal_name_identifier_prefix: "_"
 
+  value_list_talk_pages:
+    rules:
+      - class_name_identifier: _sparql_value_list
+        block_type: sparql
+        artifact_store: value_list_queries
+      - class_name_identifier: _embedded_value_list
+        block_type: json
+        artifact_store: value_list_cache
+
 spiritsafe:
   layout_version: 2
 

--- a/still/entities/Q25.json
+++ b/still/entities/Q25.json
@@ -187,10 +187,10 @@
     "workflow_mode": "recentchanges",
     "profile_entry_ids": [],
     "graph_fetched_at": "2026-04-14T13:29:28Z",
-    "cache_exported_at": "2026-04-14T13:32:14.887317Z",
+    "cache_exported_at": "2026-04-14T15:03:15.173545Z",
     "extractor": "gkc.mash.refresh_entity_cache_from_recentchanges",
     "extractor_version": "0.1.0",
-    "source_branch": null,
-    "source_commit": null
+    "source_branch": "main",
+    "source_commit": "0ec36dfc07a5b6788c15fb656d448061f24e172e"
   }
 }

--- a/still/entities/Q37.json
+++ b/still/entities/Q37.json
@@ -159,10 +159,10 @@
     "workflow_mode": "recentchanges",
     "profile_entry_ids": [],
     "graph_fetched_at": "2026-04-14T13:31:08Z",
-    "cache_exported_at": "2026-04-14T13:32:14.887317Z",
+    "cache_exported_at": "2026-04-14T15:03:15.173545Z",
     "extractor": "gkc.mash.refresh_entity_cache_from_recentchanges",
     "extractor_version": "0.1.0",
-    "source_branch": null,
-    "source_commit": null
+    "source_branch": "main",
+    "source_commit": "0ec36dfc07a5b6788c15fb656d448061f24e172e"
   }
 }

--- a/still/entities/Q43.json
+++ b/still/entities/Q43.json
@@ -126,10 +126,10 @@
     "workflow_mode": "recentchanges",
     "profile_entry_ids": [],
     "graph_fetched_at": "2026-04-14T13:01:27Z",
-    "cache_exported_at": "2026-04-14T13:32:14.887317Z",
+    "cache_exported_at": "2026-04-14T15:03:15.173545Z",
     "extractor": "gkc.mash.refresh_entity_cache_from_recentchanges",
     "extractor_version": "0.1.0",
-    "source_branch": null,
-    "source_commit": null
+    "source_branch": "main",
+    "source_commit": "0ec36dfc07a5b6788c15fb656d448061f24e172e"
   }
 }

--- a/still/entities/Q56.json
+++ b/still/entities/Q56.json
@@ -88,10 +88,10 @@
     "workflow_mode": "recentchanges",
     "profile_entry_ids": [],
     "graph_fetched_at": "2026-04-12T15:01:18Z",
-    "cache_exported_at": "2026-04-14T13:32:14.887317Z",
+    "cache_exported_at": "2026-04-14T15:03:15.173545Z",
     "extractor": "gkc.mash.refresh_entity_cache_from_recentchanges",
     "extractor_version": "0.1.0",
-    "source_branch": null,
-    "source_commit": null
+    "source_branch": "main",
+    "source_commit": "0ec36dfc07a5b6788c15fb656d448061f24e172e"
   }
 }

--- a/still/entities/Q61.json
+++ b/still/entities/Q61.json
@@ -195,10 +195,10 @@
     "workflow_mode": "recentchanges",
     "profile_entry_ids": [],
     "graph_fetched_at": "2026-04-14T11:35:13Z",
-    "cache_exported_at": "2026-04-14T12:29:34.218612Z",
+    "cache_exported_at": "2026-04-14T15:03:15.173545Z",
     "extractor": "gkc.mash.refresh_entity_cache_from_recentchanges",
     "extractor_version": "0.1.0",
-    "source_branch": null,
-    "source_commit": null
+    "source_branch": "main",
+    "source_commit": "0ec36dfc07a5b6788c15fb656d448061f24e172e"
   }
 }

--- a/still/entities/Q64.json
+++ b/still/entities/Q64.json
@@ -116,10 +116,10 @@
     "workflow_mode": "recentchanges",
     "profile_entry_ids": [],
     "graph_fetched_at": "2026-04-14T12:26:48Z",
-    "cache_exported_at": "2026-04-14T12:29:34.218612Z",
+    "cache_exported_at": "2026-04-14T15:03:15.173545Z",
     "extractor": "gkc.mash.refresh_entity_cache_from_recentchanges",
     "extractor_version": "0.1.0",
-    "source_branch": null,
-    "source_commit": null
+    "source_branch": "main",
+    "source_commit": "0ec36dfc07a5b6788c15fb656d448061f24e172e"
   }
 }

--- a/still/logs/last_run_summary.json
+++ b/still/logs/last_run_summary.json
@@ -1,21 +1,35 @@
 {
   "metadata": {
     "api_url": "https://datadistillery.wikibase.cloud/w/api.php",
-    "cache_dir": "/home/runner/work/SpiritSafe/SpiritSafe/still/entities",
-    "since": "2026-04-14T13:31:14.887317Z",
-    "next_since": "2026-04-14T13:32:14.887317Z",
+    "cache_dir": "/Users/sky/code/SpiritSafe/still/entities",
+    "since": "2026-04-13T14:59:00Z",
+    "next_since": "2026-04-14T13:31:08Z",
     "overlap_seconds": 60
   },
   "summary": {
-    "changed_count": 0,
+    "changed_count": 6,
     "ignored_count": 0,
-    "refreshed_count": 0,
+    "refreshed_count": 6,
     "deleted_count": 0,
     "missing_count": 0
   },
-  "changed_ids": [],
+  "changed_ids": [
+    "Q25",
+    "Q37",
+    "Q43",
+    "Q56",
+    "Q61",
+    "Q64"
+  ],
   "ignored_ids": [],
-  "refreshed_ids": [],
+  "refreshed_ids": [
+    "Q25",
+    "Q37",
+    "Q43",
+    "Q56",
+    "Q61",
+    "Q64"
+  ],
   "deleted_ids": [],
   "missing_ids": []
 }


### PR DESCRIPTION
## Summary

- add optional since input to the main cache refresh workflow
- sync item and property recentchanges alongside value-list talk-page artifacts
- author the class-coupled talk-page extraction rules in config/dd-wikibase.yaml
- include the latest refreshed cache summary artifacts

## Notes

- this keeps SPARQL hydration as a separate deliberate workflow
